### PR TITLE
Fix: preflight virtual-column expansion

### DIFF
--- a/hekate-sdk/src/preflight.rs
+++ b/hekate-sdk/src/preflight.rs
@@ -333,7 +333,6 @@ where
     let num_rows = trace.num_rows()?;
     let num_vars = num_rows.trailing_zeros() as usize;
     let num_virtual_cols = air.num_columns();
-    let num_physical_cols = trace.num_cols();
 
     let ast = air.constraint_ast();
     let pins = air.lagrange_pinned_columns();
@@ -344,7 +343,7 @@ where
         return Ok((Vec::new(), Vec::new()));
     }
 
-    let has_virtual_expansion = num_virtual_cols != num_physical_cols;
+    let has_virtual_expansion = air.virtual_expander().is_some();
     let phys_row_bytes: usize = if has_virtual_expansion {
         air.column_layout().iter().map(|c| c.byte_size()).sum()
     } else {
@@ -478,8 +477,53 @@ where
     P: Air<F>,
     T: Trace,
 {
-    for (bc_idx, bc) in air.boundary_constraints().iter().enumerate() {
-        let actual: Flat<F> = trace.get_element(bc.col_idx, bc.row_idx)?;
+    let bcs = air.boundary_constraints();
+    if bcs.is_empty() {
+        return Ok(());
+    }
+
+    let num_virtual = air.num_columns();
+    let num_rows = trace.num_rows()?;
+    let has_expansion = air.virtual_expander().is_some();
+    let columns = trace.columns();
+
+    let (mut row_bytes, mut virtual_row) = if has_expansion {
+        let phys_row_bytes: usize = air.column_layout().iter().map(|c| c.byte_size()).sum();
+        (
+            Vec::<u8>::with_capacity(phys_row_bytes),
+            Vec::<Flat<F>>::with_capacity(num_virtual),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    for (bc_idx, bc) in bcs.iter().enumerate() {
+        if bc.col_idx >= num_virtual {
+            return Err(errors::Error::Protocol {
+                protocol: "boundary",
+                message: "boundary col_idx out of range",
+            });
+        }
+
+        if bc.row_idx >= num_rows {
+            return Err(errors::Error::Protocol {
+                protocol: "boundary",
+                message: "boundary row_idx exceeds trace height",
+            });
+        }
+
+        let actual: Flat<F> = if has_expansion {
+            extract_row_bytes(columns, bc.row_idx, &mut row_bytes);
+
+            virtual_row.clear();
+
+            air.parse_virtual_row(&row_bytes, &mut virtual_row);
+
+            virtual_row[bc.col_idx]
+        } else {
+            trace.get_element(bc.col_idx, bc.row_idx)?
+        };
+
         let expected = bc.resolve_target(instance).unwrap_or(F::ZERO).to_hardware();
 
         if actual != expected {
@@ -644,9 +688,8 @@ where
 {
     let num_rows = trace.num_rows()?;
     let num_virtual = air.num_columns();
-    let num_physical = trace.num_cols();
 
-    let has_expansion = num_virtual != num_physical;
+    let has_expansion = air.virtual_expander().is_some();
     let want_h = spec.kind == BusKind::Lookup;
 
     let zero = Flat::from_raw(F::ZERO);

--- a/hekate-sdk/tests/preflight.rs
+++ b/hekate-sdk/tests/preflight.rs
@@ -1557,3 +1557,109 @@ fn multi_endpoint_permutation_partition_imbalance_detected() {
     assert!(d.bus_imbalance);
     assert!(d.has_failures());
 }
+
+// =================================================================
+// BOUNDARY ON EXPANDED VIRTUAL COLUMN
+// =================================================================
+
+#[derive(Clone)]
+struct ExpBoundaryChiplet;
+
+impl Air<F> for ExpBoundaryChiplet {
+    fn boundary_constraints(&self) -> Vec<BoundaryConstraint<F>> {
+        // Virtual bit 31 sits past the single physical
+        // column; it resolves only through expansion,
+        // never physical indexing.
+        vec![BoundaryConstraint::with_constant(31, 0, F::ZERO)]
+    }
+
+    fn column_layout(&self) -> &[ColumnType] {
+        &[ColumnType::B32]
+    }
+
+    fn virtual_expander(&self) -> Option<&VirtualExpander> {
+        static E: std::sync::OnceLock<VirtualExpander> = std::sync::OnceLock::new();
+        Some(E.get_or_init(|| {
+            VirtualExpander::new()
+                .expand_bits(1, ColumnType::B32)
+                .build()
+                .expect("ExpBoundaryChiplet expander")
+        }))
+    }
+
+    fn constraint_ast(&self) -> ConstraintAst<F> {
+        ConstraintSystem::<F>::new().build()
+    }
+}
+
+#[derive(Clone)]
+struct ExpBoundaryHost;
+
+impl Air<F> for ExpBoundaryHost {
+    fn num_columns(&self) -> usize {
+        0
+    }
+
+    fn column_layout(&self) -> &[ColumnType] {
+        &[]
+    }
+
+    fn constraint_ast(&self) -> ConstraintAst<F> {
+        ConstraintSystem::<F>::new().build()
+    }
+}
+
+impl Program<F> for ExpBoundaryHost {
+    fn chiplet_defs(&self) -> errors::Result<Vec<ChipletDef<F>>> {
+        Ok(vec![ChipletDef::from_air(&ExpBoundaryChiplet)?])
+    }
+}
+
+#[test]
+fn boundary_on_expanded_bit_clean_passes() {
+    let num_vars = 2;
+    let num_rows = 1 << num_vars;
+
+    let main_trace = TraceBuilder::new(&[], num_vars).unwrap().build();
+
+    // Bit 31 is 0 on every row,
+    // matching the constant-0 boundary.
+    let chiplet_trace = bit_unpack_trace(num_vars, &[]);
+
+    let instance = ProgramInstance::new(num_rows, vec![]);
+    let witness = ProgramWitness::<F>::new(main_trace).with_chiplets(vec![chiplet_trace]);
+
+    let report = preflight(&ExpBoundaryHost, &instance, &witness)
+        .expect("boundary on an expanded virtual column must not error");
+    eprintln!("{}", report);
+
+    assert!(report.is_clean());
+    assert!(report.boundary_violations.is_empty());
+}
+
+#[test]
+fn boundary_on_expanded_bit_detects_violation() {
+    let num_vars = 2;
+    let num_rows = 1 << num_vars;
+
+    let main_trace = TraceBuilder::new(&[], num_vars).unwrap().build();
+
+    // 0x8000_0000 raises bit 31 at row 0,
+    // diverging from the constant-0 boundary.
+    let chiplet_trace = bit_unpack_trace(num_vars, &[0x8000_0000]);
+
+    let instance = ProgramInstance::new(num_rows, vec![]);
+    let witness = ProgramWitness::<F>::new(main_trace).with_chiplets(vec![chiplet_trace]);
+
+    let report = preflight(&ExpBoundaryHost, &instance, &witness)
+        .expect("boundary on an expanded virtual column must not error");
+    eprintln!("{}", report);
+
+    assert!(!report.is_clean());
+    assert_eq!(report.boundary_violations.len(), 1);
+
+    let v = &report.boundary_violations[0];
+    assert!(matches!(v.table, TableId::Chiplet(0)));
+    assert_eq!(v.col_idx, 31);
+    assert_eq!(v.row_idx, 0);
+}


### PR DESCRIPTION
`preflight` indexed the physical trace with *virtual* column indices, so boundary checks on any `expand_bits` AIR returned `ColumnIndexOutOfBounds` instead of evaluating. Now expands the row first; discriminator unified to `virtual_expander().is_some()`.

## Changes
- `check_boundary_constraints`: expand the virtual row before indexing; bounds-check col/row -> `Error::Protocol{"boundary"}`.
- Unify expand/no-expand discriminator to `air.virtual_expander().is_some()` across boundary, constraint/pin, and bus paths (drops the `num_virtual != num_physical` proxy).
- Boundary scratch allocated only on the expansion path.

## Tests
`boundary_on_expanded_bit_clean_passes` + `boundary_on_expanded_bit_detects_violation` (red pre-fix via OOB, green after). Full preflight suite green serial + `--features parallel`; clippy `-D warnings` clean.

## Risk
Patch **0.28.1**, non-breaking, no public API change, behavior-only bug fix; stays within consumers' `"0.28"` range.