### PR TITLE
Operational hardening: bus-id validation, config presets, selector lint

### DIFF
--- a/hekate-core/src/config.rs
+++ b/hekate-core/src/config.rs
@@ -20,6 +20,11 @@ use crate::utils::compute_split_vars;
 use core::fmt;
 use tracing::warn;
 
+/// Production soundness floor:
+/// full GF(2^128) security. `security_bits` caps
+/// at the field size, 128 is the strongest attainable.
+pub const MIN_PRODUCTION_BITS: usize = 128;
+
 /// Failures produced by `Config::check_security`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -115,18 +120,36 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            expansion_degree: 16,
-            num_queries: 160,
-            matrix_seed: [42u8; 32],
-            min_security_bits: 99,
-            sumcheck_blinding_factor: 2,
-            ldt_blinding_factor: 200,
-        }
+        Self::prod()
     }
 }
 
 impl Config {
+    /// Production parameters: ≈128-bit soundness
+    /// with the `MIN_PRODUCTION_BITS` acceptance
+    /// threshold. The `Default`.
+    pub fn prod() -> Self {
+        Self {
+            expansion_degree: 16,
+            num_queries: 160,
+            matrix_seed: [42u8; 32],
+            min_security_bits: MIN_PRODUCTION_BITS,
+            sumcheck_blinding_factor: 2,
+            ldt_blinding_factor: 200,
+        }
+    }
+
+    /// Fast, low-soundness parameters for tests
+    /// and experiments; `min_security_bits = 0`
+    /// accepts weak grids. Never deploy.
+    pub fn dev() -> Self {
+        Self {
+            num_queries: 4,
+            min_security_bits: 0,
+            ..Self::prod()
+        }
+    }
+
     /// `min(-log₂((1 - δ)^q), field_bits)` where
     /// δ = relative distance, q = num_queries.
     ///
@@ -159,8 +182,8 @@ impl Config {
     }
 
     /// Rejects configs that can't meet
-    /// `min_security_bits` for the given
-    /// trace dimensions.
+    /// `min_security_bits` for the
+    /// given trace dimensions.
     pub fn check_security(&self, num_vars: usize, field_bits: usize) -> errors::Result<()> {
         if self.ldt_blinding_factor < self.num_queries {
             return Err(Error::InsufficientLdtBlinding {
@@ -230,5 +253,42 @@ impl Config {
         };
 
         (theoretical_delta * correction_factor).max(0.01)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_prod() {
+        assert_eq!(Config::default().min_security_bits, MIN_PRODUCTION_BITS);
+        assert_eq!(Config::default().num_queries, Config::prod().num_queries);
+    }
+
+    #[test]
+    fn prod_meets_production_floor() {
+        let prod = Config::prod();
+
+        assert!(prod.estimated_security_bits(128) >= MIN_PRODUCTION_BITS);
+        assert!(prod.check_security(10, 128).is_ok());
+    }
+
+    #[test]
+    fn dev_is_lenient_on_weak_params() {
+        let dev = Config::dev();
+
+        assert!(dev.estimated_security_bits(128) < MIN_PRODUCTION_BITS);
+        assert!(dev.check_security(10, 128).is_ok());
+    }
+
+    #[test]
+    fn prod_threshold_rejects_weak_queries() {
+        let weak = Config {
+            num_queries: 4,
+            ..Config::prod()
+        };
+
+        assert!(weak.check_security(10, 128).is_err());
     }
 }

--- a/hekate-program/src/chiplet.rs
+++ b/hekate-program/src/chiplet.rs
@@ -555,6 +555,38 @@ fn validate_chiplet_boundaries<F>(
     Ok(())
 }
 
+/// Non-paired `Bit` selectors with no direct
+/// `s·s + s` boolean root, each tagged with the
+/// declaring `bus_id`. Advisory only: booleanness
+/// can hold indirectly (one-hot, disjoint
+/// products), callers warn rather than reject.
+pub fn unconstrained_bit_selectors<'a, F: TowerField>(
+    specs: &'a [(String, PermutationCheckSpec)],
+    ast: &ConstraintAst<F>,
+    virtual_layout: &[ColumnType],
+) -> Vec<(usize, &'a str)> {
+    let mut flagged: Vec<(usize, &str)> = Vec::new();
+    for (bus_id, spec) in specs {
+        if spec.recv_selector.is_some() {
+            continue;
+        }
+
+        let Some(sel) = spec.selector else {
+            continue;
+        };
+
+        if virtual_layout.get(sel) != Some(&ColumnType::Bit) {
+            continue;
+        }
+
+        if !ast_contains_boolean_root(ast, sel) && !flagged.iter().any(|(s, _)| *s == sel) {
+            flagged.push((sel, bus_id.as_str()));
+        }
+    }
+
+    flagged
+}
+
 fn ast_contains_mutex_root<F: TowerField>(
     ast: &ConstraintAst<F>,
     s_send: usize,
@@ -915,5 +947,36 @@ mod tests {
             &[("asym_bus".into(), spec)],
             &ast,
         ));
+    }
+
+    #[test]
+    fn flags_bit_selector_without_boolean_root() {
+        let ast = ConstraintSystem::<F>::new().build();
+        let layout = vec![ColumnType::B32, ColumnType::Bit];
+        let specs = vec![(
+            String::from("bus"),
+            PermutationCheckSpec::new(vec![(Source::Column(0), b"k" as ChallengeLabel)], Some(1)),
+        )];
+
+        assert_eq!(
+            unconstrained_bit_selectors(&specs, &ast, &layout),
+            vec![(1, "bus")]
+        );
+    }
+
+    #[test]
+    fn boolean_root_clears_bit_selector() {
+        let cs = ConstraintSystem::<F>::new();
+        let sel = cs.col(1);
+        cs.assert_boolean(sel);
+        let ast = cs.build();
+
+        let layout = vec![ColumnType::B32, ColumnType::Bit];
+        let specs = vec![(
+            String::from("bus"),
+            PermutationCheckSpec::new(vec![(Source::Column(0), b"k" as ChallengeLabel)], Some(1)),
+        )];
+
+        assert!(unconstrained_bit_selectors(&specs, &ast, &layout).is_empty());
     }
 }

--- a/hekate-program/src/permutation.rs
+++ b/hekate-program/src/permutation.rs
@@ -295,6 +295,16 @@ where
     let mut by_bus: BTreeMap<&'a str, Vec<&'a PermutationCheckSpec>> = BTreeMap::new();
 
     for (bus_id, spec) in endpoints {
+        if !bus_id.bytes().all(|b| b.is_ascii_graphic()) {
+            return Err(errors::Error::Protocol {
+                protocol: "logup_bus",
+                message: "bus_id has a non-graphic byte; bus ids must be \
+                          graphic ASCII (0x21..=0x7E). A space, zero-width, \
+                          or homoglyph byte forges a visually identical \
+                          second bus that balances on its own",
+            });
+        }
+
         by_bus.entry(bus_id).or_default().push(spec);
     }
 
@@ -447,5 +457,29 @@ mod tests {
             Source::Columns(idxs) => assert_eq!(idxs, &vec![11, 12]),
             other => panic!("expected Columns, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn validate_bus_set_rejects_homoglyph_split_bus() {
+        let clockless =
+            PermutationCheckSpec::new(vec![(Source::Column(0), b"k" as ChallengeLabel)], Some(1));
+        let other = clockless.clone();
+
+        assert!(validate_bus_set(vec![("ram_link", &clockless), ("ram_link", &other)]).is_err());
+
+        // A zero-width twin splits this into two
+        // single-endpoint buses that skip the
+        // clock gate; the ASCII check blocks it.
+        assert!(
+            validate_bus_set(vec![("ram_link", &clockless), ("ram_link\u{200b}", &other)]).is_err()
+        );
+    }
+
+    #[test]
+    fn validate_bus_set_accepts_ascii_bus_id() {
+        let spec =
+            PermutationCheckSpec::new(vec![(Source::Column(0), b"k" as ChallengeLabel)], Some(1));
+
+        assert!(validate_bus_set(vec![("ram_link", &spec)]).is_ok());
     }
 }

--- a/hekate-verifier/src/lib.rs
+++ b/hekate-verifier/src/lib.rs
@@ -160,10 +160,37 @@ where
                 spec.validate_clock_stitching(bus_id)?;
             }
 
-            chiplet::validate_paired_bus_mutex(&def.permutation_checks, &def.constraint_ast())?;
+            let def_ast = def.constraint_ast();
+            chiplet::validate_paired_bus_mutex(&def.permutation_checks, &def_ast)?;
+
+            for (sel, bus) in chiplet::unconstrained_bit_selectors(
+                &def.permutation_checks,
+                &def_ast,
+                Air::<F>::virtual_column_layout(def),
+            ) {
+                warn!(
+                    chiplet = %def.name(),
+                    bus,
+                    selector = sel,
+                    "chiplet bus Bit selector lacks a boolean-assertion root"
+                );
+            }
         }
 
-        chiplet::validate_paired_bus_mutex(&main_perm, &program.constraint_ast())?;
+        let main_ast = program.constraint_ast();
+        chiplet::validate_paired_bus_mutex(&main_perm, &main_ast)?;
+
+        for (sel, bus) in chiplet::unconstrained_bit_selectors(
+            &main_perm,
+            &main_ast,
+            program.virtual_column_layout(),
+        ) {
+            warn!(
+                bus,
+                selector = sel,
+                "main bus Bit selector lacks a boolean-assertion root"
+            );
+        }
 
         let all_endpoints = main_perm.iter().map(|(id, s)| (id.as_str(), s)).chain(
             chiplet_defs_for_check


### PR DESCRIPTION
Three independent hardening changes in the program and verifier layers. Each is self-contained
(no prover-side change) and safe against existing usage.

## Changes

### `fix(program): reject non-ASCII bus_id in validate_bus_set`

`validate_bus_set` keyed buses by `bus_id` with no byte inspection, so a zero-width or homoglyph twin: `"ram_link\u{200b}"` vs `"ram_link"`, is byte-distinct and splits one 2-endpoint bus into two single-endpoint buses. Each then takes the `specs.len() < 2 → continue` path and skips clock-stitching validation entirely. The fix rejects any `bus_id` byte that is not `is_ascii_graphic`. Every existing bus_id is ASCII snake_case, so no legitimate id is affected.

### `feat(core): config prod()/dev() presets, production by default`

`Config::default()` set `min_security_bits = 99`, so `check_security` would accept a downgraded config below full 128-bit soundness. `Default` is now `Config::prod()` (`min_security_bits = 128`, the field-size cap); `Config::dev()` carries the fast, lenient params tests use. Production security is the default, and dropping below it is an explicit `dev()` or `min_security_bits: 0` at the construction site. Enforcement stays in the existing `check_security`, no new verifier path and no call-site churn.

### `feat(program,verifier): warn on unconstrained Bit bus selectors`

Non-paired `Bit` bus selectors lacking a direct `s·s + s` boolean-assertion root are now logged (selector index + bus_id) once per verify. This is a warning, not a hard error: a hard gate false-positives on one-hot and disjoint-product selectors that are boolean only indirectly. Pure detector reusing the existing AST machinery; no new dependency.

## Testing

- Unit: `hekate-core` (config presets and threshold) and `hekate-program` (`permutation` homoglyph rejection, `chiplet` selector detector) pass; `hekate-verifier` compiles.
- Integration: `hekate` `security_exploits` (24) and `full_program` (4) pass: covers config transcript binding and the `Config::default()` prove->verify path.
- `cargo fmt --check` and `clippy -D warnings` clean on `hekate-core`, `hekate-program`, `hekate-verifier`.