### PR TITLE
Virtual expansion: ReuseExpandBits for bit-expanding reused physical columns

### DIFF
--- a/hekate-program/src/expander.rs
+++ b/hekate-program/src/expander.rs
@@ -41,6 +41,11 @@ pub enum ExpansionEntry {
         count: usize,
         storage: ColumnType,
     },
+    ReuseExpandBits {
+        phy_col_start: usize,
+        count: usize,
+        storage: ColumnType,
+    },
 }
 
 /// Physical-to-virtual column mapping rule.
@@ -210,10 +215,9 @@ impl VirtualExpander {
         self
     }
 
-    /// Emit pass-through for columns
-    /// already declared by a prior
-    /// fresh entry. Does not advance
-    /// the physical cursor.
+    /// Emit pass-through for columns already
+    /// declared by a prior fresh entry.
+    /// Does not advance the physical cursor.
     pub fn reuse_pass_through(mut self, phy_col_start: usize, count: usize) -> Self {
         if self.error.is_some() {
             return self;
@@ -245,6 +249,54 @@ impl VirtualExpander {
         self.virtual_layout.extend(repeat_n(storage, count));
 
         self.num_virtual += count;
+
+        self
+    }
+
+    /// Emit bit-expansion for columns already
+    /// declared by a prior fresh entry.
+    /// Does not advance the physical cursor.
+    pub fn reuse_expand_bits(mut self, phy_col_start: usize, count: usize) -> Self {
+        if self.error.is_some() {
+            return self;
+        }
+
+        if phy_col_start + count > self.num_physical {
+            self.error = Some(Error::Protocol {
+                protocol: "virtual_expand",
+                message: "reuse_expand_bits: range exceeds declared physical columns",
+            });
+            return self;
+        }
+
+        let (byte_offset, storage) = match self.find_phy_source(phy_col_start, count) {
+            Ok(v) => v,
+            Err(e) => {
+                self.error = Some(e);
+                return self;
+            }
+        };
+
+        let bits_per = match expand_bit_width(storage) {
+            Ok(v) => v,
+            Err(e) => {
+                self.error = Some(e);
+                return self;
+            }
+        };
+
+        self.entries.push(CompiledEntry {
+            phy_col_start,
+            byte_offset,
+            kind: EntryKind::ExpandBits { count, storage },
+            reuse: true,
+        });
+
+        let virt_count = count * bits_per;
+        self.virtual_layout
+            .extend(repeat_n(ColumnType::Bit, virt_count));
+
+        self.num_virtual += virt_count;
 
         self
     }
@@ -391,7 +443,14 @@ impl VirtualExpander {
                         storage,
                     }
                 }
-                (EntryKind::ExpandBits { count, storage }, _) => {
+                (EntryKind::ExpandBits { count, storage }, true) => {
+                    ExpansionEntry::ReuseExpandBits {
+                        phy_col_start: e.phy_col_start,
+                        count,
+                        storage,
+                    }
+                }
+                (EntryKind::ExpandBits { count, storage }, false) => {
                     ExpansionEntry::ExpandBits { count, storage }
                 }
                 (EntryKind::PassThrough { count, storage }, false) => {
@@ -433,7 +492,7 @@ impl VirtualExpander {
 
         Err(Error::Protocol {
             protocol: "virtual_expand",
-            message: "reuse_pass_through: source columns not found in any fresh entry",
+            message: "reuse: source columns not found in any single fresh entry",
         })
     }
 }
@@ -653,6 +712,41 @@ mod tests {
         let result = VirtualExpander::new()
             .expand_bits(5, ColumnType::B32)
             .reuse_pass_through(3, 5)
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reuse_expand_bits_from_pass_through() {
+        let e = VirtualExpander::new()
+            .pass_through(4, ColumnType::B64)
+            .reuse_expand_bits(0, 4)
+            .build()
+            .unwrap();
+
+        assert_eq!(e.num_physical_columns(), 4);
+        assert_eq!(e.physical_row_bytes(), 32);
+        assert_eq!(e.num_virtual_columns(), 4 + 256);
+
+        let layout = e.virtual_layout();
+        assert!(layout[0..4].iter().all(|&t| t == ColumnType::B64));
+        assert!(layout[4..260].iter().all(|&t| t == ColumnType::Bit));
+    }
+
+    #[test]
+    fn reuse_expand_bits_exceeds_declared() {
+        let result = VirtualExpander::new()
+            .pass_through(4, ColumnType::B64)
+            .reuse_expand_bits(2, 4)
+            .build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reuse_expand_bits_rejects_b128_source() {
+        let result = VirtualExpander::new()
+            .pass_through(1, ColumnType::B128)
+            .reuse_expand_bits(0, 1)
             .build();
         assert!(result.is_err());
     }

--- a/hekate-sdk/schema/hekate_program.fbs
+++ b/hekate-sdk/schema/hekate_program.fbs
@@ -96,7 +96,8 @@ enum ExpansionKind : byte {
   ExpandBits,
   PassThrough,
   ControlBits,
-  ReusePassThrough
+  ReusePassThrough,
+  ReuseExpandBits
 }
 
 table ExpansionEntry {

--- a/hekate-sdk/src/builder.rs
+++ b/hekate-sdk/src/builder.rs
@@ -399,6 +399,16 @@ fn absorb_expander(h: &mut DefaultHasher, exp: &hekate_program::expander::Virtua
                 h.update(&(count as u64).to_le_bytes());
                 h.update(&[column_type_tag(storage)]);
             }
+            ExpansionEntry::ReuseExpandBits {
+                phy_col_start,
+                count,
+                storage,
+            } => {
+                h.update(&[4]);
+                h.update(&(phy_col_start as u64).to_le_bytes());
+                h.update(&(count as u64).to_le_bytes());
+                h.update(&[column_type_tag(storage)]);
+            }
         }
     }
 }

--- a/hekate-sdk/src/generated/hekate_program_generated.rs
+++ b/hekate-sdk/src/generated/hekate_program_generated.rs
@@ -522,17 +522,18 @@ pub mod hekate {
             since = "2.0.0",
             note = "Use associated constants instead. This will no longer be generated in 2021."
         )]
-        pub const ENUM_MAX_EXPANSION_KIND: i8 = 3;
+        pub const ENUM_MAX_EXPANSION_KIND: i8 = 4;
         #[deprecated(
             since = "2.0.0",
             note = "Use associated constants instead. This will no longer be generated in 2021."
         )]
         #[allow(non_camel_case_types)]
-        pub const ENUM_VALUES_EXPANSION_KIND: [ExpansionKind; 4] = [
+        pub const ENUM_VALUES_EXPANSION_KIND: [ExpansionKind; 5] = [
             ExpansionKind::ExpandBits,
             ExpansionKind::PassThrough,
             ExpansionKind::ControlBits,
             ExpansionKind::ReusePassThrough,
+            ExpansionKind::ReuseExpandBits,
         ];
 
         #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -544,14 +545,16 @@ pub mod hekate {
             pub const PassThrough: Self = Self(1);
             pub const ControlBits: Self = Self(2);
             pub const ReusePassThrough: Self = Self(3);
+            pub const ReuseExpandBits: Self = Self(4);
 
             pub const ENUM_MIN: i8 = 0;
-            pub const ENUM_MAX: i8 = 3;
+            pub const ENUM_MAX: i8 = 4;
             pub const ENUM_VALUES: &'static [Self] = &[
                 Self::ExpandBits,
                 Self::PassThrough,
                 Self::ControlBits,
                 Self::ReusePassThrough,
+                Self::ReuseExpandBits,
             ];
             /// Returns the variant's name or "" if unknown.
             pub fn variant_name(self) -> Option<&'static str> {
@@ -560,6 +563,7 @@ pub mod hekate {
                     Self::PassThrough => Some("PassThrough"),
                     Self::ControlBits => Some("ControlBits"),
                     Self::ReusePassThrough => Some("ReusePassThrough"),
+                    Self::ReuseExpandBits => Some("ReuseExpandBits"),
                     _ => None,
                 }
             }

--- a/hekate-sdk/src/wire/expander.rs
+++ b/hekate-sdk/src/wire/expander.rs
@@ -52,6 +52,16 @@ pub fn serialize_expander<'a>(
                     storage,
                     phy_col_start,
                 ),
+                ExpansionEntry::ReuseExpandBits {
+                    phy_col_start,
+                    count,
+                    storage,
+                } => (
+                    fb::ExpansionKind::ReuseExpandBits,
+                    count,
+                    storage,
+                    phy_col_start,
+                ),
             };
 
             fb::ExpansionEntry::create(
@@ -95,6 +105,9 @@ pub fn deserialize_expander(fb_exp: fb::VirtualExpander<'_>) -> Result<VirtualEx
             fb::ExpansionKind::ControlBits => builder.control_bits(count),
             fb::ExpansionKind::ReusePassThrough => {
                 builder.reuse_pass_through(entry.phy_col_start() as usize, count)
+            }
+            fb::ExpansionKind::ReuseExpandBits => {
+                builder.reuse_expand_bits(entry.phy_col_start() as usize, count)
             }
             _ => {
                 return Err(Error::Protocol {


### PR DESCRIPTION
Adds one VirtualExpander variant and its wire/program_id plumbing. Additive and self-contained: no chiplet consumes it yet, the prover binary is unchanged, and every existing program is byte-for-byte unaffected.

## Changes

### `feat(program): add ReuseExpandBits virtual-expansion variant`

VirtualExpander could pass reused physical columns through unchanged (`ReusePassThrough`) but could not bit-expand them, the inverse of the Keccak shape, where a column stored wide is also needed as individual bits. `reuse_expand_bits(phy_col_start, count)` adds that: it bit-expands columns already declared by a prior fresh entry without advancing the physical cursor, mirroring `reuse_pass_through`.

The load-bearing change is the descriptor mapping: `(ExpandBits, reuse)` now splits on the reuse flag so a reused expansion serializes as `ReuseExpandBits`, not as a fresh `ExpandBits`. Without the split a reuse entry would deserialize as a fresh `expand_bits`, advance the physical cursor a second time, and corrupt the committed row byte-offset on round-trip. The hot paths (`parse_row`, `expand_variants`) stay reuse-agnostic, the backward pointer lives in the precomputed byte offset and physical index, so they need no change.

The shared `find_phy_source` error message is generalized, it now serves both reuse builders, and the bit-width rejection path (reusing a B128 or Bit source, neither of which can bit-expand) is covered.

### `feat(sdk): add ReuseExpandBits to the flatbuffers ExpansionKind`

Appends the enum value to the wire schema and regenerates the bindings.

### `feat(sdk): bind and serialize ReuseExpandBits in program_id and wire`

Hashes the variant under a distinct program_id tag so a reused bit-expansion is not collision-equal to a reused pass-through over the same columns, and adds the serialize/deserialize arms so the expander descriptor round-trips intact.

## Testing

- Unit: `hekate-program` expander suite (12), parse/expand round-trip, reuse layouts including the Keccak-style wide-plus-bits shape, and B128-source rejection. `hekate-sdk` (91) including the virtual-expander program_id binding tests.
- Integration: `hekate` full suite (135) passes in both debug and release against the pinned prover, confirming existing programs prove and verify unchanged.
- `cargo fmt --check` clean on the touched crates.