### PR TITLE
Preflight: hoist constant basis-conversion out of the AST row loop

### DIFF
--- a/hekate-program/src/constraint/mod.rs
+++ b/hekate-program/src/constraint/mod.rs
@@ -357,49 +357,47 @@ impl<F: TowerField> ConstraintAst<F> {
             .unwrap_or(0)
     }
 
+    /// Hardware-basis `Const`/`Scale` coefficients
+    /// indexed by `ExprId`; other slots hold zero.
+    pub fn precompute_hardware_consts(&self) -> Vec<Flat<F>>
+    where
+        F: HardwareField,
+    {
+        let n = self.arena.len();
+
+        let mut consts: Vec<Flat<F>> = Vec::with_capacity(n);
+        for i in 0..n {
+            let c = match self.arena.get(ExprId(i as u32)) {
+                ConstraintExpr::Const(k) => k.to_hardware(),
+                ConstraintExpr::Scale(k, _) => k.to_hardware(),
+                _ => Flat::from_raw(F::ZERO),
+            };
+
+            consts.push(c);
+        }
+
+        consts
+    }
+
     /// Evaluate each constraint
     /// root at a single point.
     pub fn evaluate(&self, current_row: &[Flat<F>], next_row: &[Flat<F>]) -> Vec<Flat<F>>
     where
         F: HardwareField,
     {
-        let n = self.arena.len();
-        let mut val: Vec<Flat<F>> = Vec::with_capacity(n);
+        let consts = self.precompute_hardware_consts();
+        let mut buf: Vec<Flat<F>> = Vec::with_capacity(self.arena.len());
 
-        for i in 0..n {
-            let v = match self.arena.get(ExprId(i as u32)) {
-                ConstraintExpr::Cell(cell) => {
-                    if cell.next_row {
-                        next_row[cell.col_idx]
-                    } else {
-                        current_row[cell.col_idx]
-                    }
-                }
-                ConstraintExpr::Const(k) => k.to_hardware(),
-                ConstraintExpr::Add(a, b) => val[a.0 as usize] + val[b.0 as usize],
-                ConstraintExpr::Mul(a, b) => val[a.0 as usize] * val[b.0 as usize],
-                ConstraintExpr::Scale(k, a) => k.to_hardware() * val[a.0 as usize],
-                ConstraintExpr::Sum(children) => {
-                    let mut s = Flat::from_raw(F::ZERO);
-                    for c in children {
-                        s += val[c.0 as usize];
-                    }
+        self.evaluate_into(&consts, current_row, next_row, &mut buf);
 
-                    s
-                }
-            };
-
-            val.push(v);
-        }
-
-        self.roots.iter().map(|r| val[r.0 as usize]).collect()
+        self.roots.iter().map(|r| buf[r.0 as usize]).collect()
     }
 
-    /// Buffer-reuse variant of `evaluate()`.
-    /// Caller owns `buf`; reused across
-    /// rows to avoid per-row allocation.
+    /// `consts` must come from the same arena
+    /// `self.precompute_hardware_consts()`.
     pub fn evaluate_into(
         &self,
+        consts: &[Flat<F>],
         current_row: &[Flat<F>],
         next_row: &[Flat<F>],
         buf: &mut Vec<Flat<F>>,
@@ -408,8 +406,7 @@ impl<F: TowerField> ConstraintAst<F> {
     {
         buf.clear();
 
-        let n = self.arena.len();
-        for i in 0..n {
+        for (i, &coeff) in consts.iter().enumerate() {
             let v = match self.arena.get(ExprId(i as u32)) {
                 ConstraintExpr::Cell(cell) => {
                     if cell.next_row {
@@ -418,10 +415,10 @@ impl<F: TowerField> ConstraintAst<F> {
                         current_row[cell.col_idx]
                     }
                 }
-                ConstraintExpr::Const(k) => k.to_hardware(),
+                ConstraintExpr::Const(_) => coeff,
                 ConstraintExpr::Add(a, b) => buf[a.0 as usize] + buf[b.0 as usize],
                 ConstraintExpr::Mul(a, b) => buf[a.0 as usize] * buf[b.0 as usize],
-                ConstraintExpr::Scale(k, a) => k.to_hardware() * buf[a.0 as usize],
+                ConstraintExpr::Scale(_, a) => coeff * buf[a.0 as usize],
                 ConstraintExpr::Sum(children) => {
                     let mut s = Flat::from_raw(F::ZERO);
                     for c in children {
@@ -922,8 +919,10 @@ mod tests {
 
         let expected = ast.evaluate(&current, &next);
 
+        let consts = ast.precompute_hardware_consts();
+
         let mut buf = Vec::new();
-        ast.evaluate_into(&current, &next, &mut buf);
+        ast.evaluate_into(&consts, &current, &next, &mut buf);
 
         for (i, root) in ast.roots.iter().enumerate() {
             assert_eq!(buf[root.0 as usize], expected[i]);

--- a/hekate-sdk/src/preflight.rs
+++ b/hekate-sdk/src/preflight.rs
@@ -212,6 +212,7 @@ fn evaluate_air_row<F, P, T>(
     trace: &T,
     table: TableId,
     ast: &ConstraintAst<F>,
+    consts: &[Flat<F>],
     pins: &[FixedColumn<F>],
     num_virtual_cols: usize,
     has_virtual_expansion: bool,
@@ -275,6 +276,7 @@ where
     }
 
     ast.evaluate_into(
+        consts,
         &scratch.current_row,
         &scratch.next_row,
         &mut scratch.eval_buf,
@@ -328,6 +330,7 @@ where
     };
 
     let ast_arena_len = ast.arena.len();
+    let consts = ast.precompute_hardware_consts();
 
     #[cfg(not(feature = "parallel"))]
     {
@@ -341,6 +344,7 @@ where
                 trace,
                 table,
                 &ast,
+                &consts,
                 &pins,
                 num_virtual_cols,
                 has_virtual_expansion,
@@ -373,6 +377,7 @@ where
                         trace,
                         table,
                         &ast,
+                        &consts,
                         &pins,
                         num_virtual_cols,
                         has_virtual_expansion,


### PR DESCRIPTION
`ConstraintAst::evaluate_into` re-converted every `Const`/`Scale` coefficient from tower to hardware basis on every row: loop-invariant work that dominated preflight. Precompute the hardware-basis coefficients once and read them per row. Internal and result-preserving: no wire, `program_id`, or proof-byte change, and the prover (which converts AST constants once at compile time) and the single-point verifier are both unaffected. Measured ~6x on per-row constraint evaluation and ~4.8x on full preflight over a 2^15 Keccak chiplet.

## Changes

### `perf(program): hoist constant basis-conversion out of AST evaluation`

`evaluate_into` evaluated the arena per row and called `to_hardware()` (~90 ns, constant-time bitslice) on every `Const` and `Scale` node each row. The coefficient is loop-invariant, for a trace of `N` rows each constant was converted `N` times, 1601 conversions per row for the Keccak chiplet (1600 lane-packing `Scale` nodes plus one `Const`), ~138 us of the ~164 us per-row cost.

`precompute_hardware_consts()` builds the hardware-basis coefficient table once, indexed by `ExprId` (non-`Const`/`Scale` slots hold zero). `evaluate_into` gains a leading `consts: &[Flat<F>]` parameter and reads the table for `Const`/`Scale` instead of converting. `evaluate()` — the single-point path, signature unchanged, is rerouted through `precompute_hardware_consts` + `evaluate_into`, so there is exactly one evaluation loop and the verifier and gadget callers are untouched. Output is bit-identical; the in-crate `evaluate_into_matches_evaluate` test pins the table path to the reference.

### `perf(sdk): evaluate preflight constraints from the precomputed table`

`collect_air_violations` builds the constant table once per table (after fetching the AST, before the row loop) and threads it through `evaluate_air_row` into `evaluate_into`, on both the sequential and the rayon `try_fold` paths. Per-row AIR evaluation no longer re-converts loop-invariant constants. The table is a shared immutable borrow across the parallel fold; the bus and boundary phases are unchanged.

## Compatibility

- API: `ConstraintAst::evaluate_into` gains a leading `consts: &[Flat<F>]`; callers obtain it from `precompute_hardware_consts()`. `evaluate()` (verifier and gadget path) is unchanged.
- Unchanged: evaluation results are bit-identical; no wire, `program_id`, or proof-byte change. The prover never calls `evaluate_into`, and the verifier evaluates a single point, so both are unaffected.