### PR TITLE
pqcrypto -> RustCrypto ml-kem/ml-dsa + yanked aes bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd29a732b644c0431c6140f370d097879203d79b80c94a6747ba0872adaef8"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",
@@ -213,8 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -296,6 +294,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "const-oid"
@@ -421,7 +425,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -510,19 +525,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -685,12 +694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,9 +748,8 @@ dependencies = [
  "hekate-sdk",
  "hekate-verifier",
  "keccak",
- "pqcrypto-mldsa",
- "pqcrypto-mlkem",
- "pqcrypto-traits",
+ "ml-dsa",
+ "ml-kem",
  "proptest",
  "rand 0.9.4",
  "rayon",
@@ -869,8 +871,7 @@ dependencies = [
  "hekate-sdk",
  "hekate-verifier",
  "hex",
- "pqcrypto-mldsa",
- "pqcrypto-traits",
+ "ml-dsa",
  "serde",
  "sha2 0.11.0",
  "spki 0.8.0",
@@ -934,6 +935,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
+ "ctutils",
  "typenum",
 ]
 
@@ -980,16 +982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1001,16 @@ checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1079,6 +1081,47 @@ name = "mintex"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha3",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1153,12 +1196,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,51 +1281,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "pqcrypto-internals"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a326caf27cbf2ac291ca7fd56300497ba9e76a8cc6a7d95b7a18b57f22b61d"
-dependencies = [
- "cc",
- "dunce",
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "pqcrypto-mldsa"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f812cd126a2582599478a434fea75937b4b05d234c64a49e0cea129e130528"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "paste",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-mlkem"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb14d207f3749e8a59a026c22ceaa72d70fff931cfbf4c8d9b08f3fc56dc6e60"
-dependencies = [
- "cc",
- "glob",
- "libc",
- "pqcrypto-internals",
- "pqcrypto-traits",
-]
-
-[[package]]
-name = "pqcrypto-traits"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e851c7654eed9e68d7d27164c454961a616cf8c203d500607ef22c737b51bb"
 
 [[package]]
 name = "prettyplease"
@@ -1674,6 +1676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1708,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1730,6 +1753,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,7 +1782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/deny.toml
+++ b/deny.toml
@@ -9,10 +9,6 @@ ignore = [
     # development after a doxxing incident;
     # no CVE, no upgrade path.
     { id = "RUSTSEC-2025-0141", reason = "dev-only proof-size example; upstream archived, no security vulnerability" },
-    # paste 1.0.15, transitive dep of pqcrypto-mldsa.
-    # Repo archived; no CVE, no upgrade path
-    # until pqcrypto migrates.
-    { id = "RUSTSEC-2024-0436", reason = "transitive via pqcrypto-mldsa; upstream archived, no security vulnerability" },
 ]
 
 [licenses]

--- a/hekate-prover-sys/Cargo.toml
+++ b/hekate-prover-sys/Cargo.toml
@@ -32,8 +32,7 @@ toml = { version = "1", default-features = false, features = ["parse", "serde"] 
 serde = { workspace = true, features = ["std"] }
 sha2 = { version = "0.11", default-features = false }
 ed25519-dalek = { version = "2", default-features = false, features = ["pem", "std"] }
-pqcrypto-mldsa = { version = "0.1", default-features = false, features = ["std"] }
-pqcrypto-traits = { version = "0.3", default-features = false, features = ["std"] }
+ml-dsa = { version = "0.1", default-features = false }
 spki = { version = "0.8", default-features = false, features = ["alloc", "pem"] }
 base64 = { version = "0.22", default-features = false, features = ["std"] }
 hex = { version = "0.4", default-features = false, features = ["std"] }

--- a/hekate-prover-sys/build.rs
+++ b/hekate-prover-sys/build.rs
@@ -19,10 +19,8 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as B64;
 use ed25519_dalek::pkcs8::DecodePublicKey as _;
 use ed25519_dalek::{Signature as EdSignature, VerifyingKey as EdKey};
-use pqcrypto_mldsa::mldsa65;
-use pqcrypto_traits::sign::{
-    DetachedSignature as _, PublicKey as _, VerificationError as MlVerifyErr,
-};
+use ml_dsa::signature::Verifier as _;
+use ml_dsa::{EncodedVerifyingKey, MlDsa65, Signature, VerifyingKey};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use spki::{SubjectPublicKeyInfoOwned, der::Decode};
@@ -311,18 +309,18 @@ fn verify_mldsa65(
     pubkey_pem: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let raw_pub = spki_subject_public_key(pubkey_pem)?;
-    let key = mldsa65::PublicKey::from_bytes(&raw_pub)
-        .map_err(|e| format!("ML-DSA-65 pubkey from raw bytes: {e:?}"))?;
+    let enc_vk = <&EncodedVerifyingKey<MlDsa65>>::try_from(raw_pub.as_slice())
+        .map_err(|_| format!("ML-DSA-65 pubkey wrong length: {} bytes", raw_pub.len()))?;
+    let key = VerifyingKey::<MlDsa65>::decode(enc_vk);
 
     let sig_bytes = B64
         .decode(sig_b64.trim())
         .map_err(|e| format!("ML-DSA-65 sig base64: {e}"))?;
-    let sig = mldsa65::DetachedSignature::from_bytes(&sig_bytes)
-        .map_err(|e| format!("ML-DSA-65 sig from bytes: {e:?}"))?;
+    let signature = Signature::<MlDsa65>::try_from(sig_bytes.as_slice())
+        .map_err(|_| format!("ML-DSA-65 sig wrong length: {} bytes", sig_bytes.len()))?;
 
-    mldsa65::verify_detached_signature(&sig, msg, &key).map_err(|e: MlVerifyErr| {
-        Box::<dyn std::error::Error>::from(format!("ML-DSA-65 verification failed: {e:?}"))
-    })?;
+    key.verify(msg, &signature)
+        .map_err(|e| format!("ML-DSA-65 verification failed: {e}"))?;
 
     Ok(())
 }

--- a/hekate/Cargo.toml
+++ b/hekate/Cargo.toml
@@ -66,9 +66,8 @@ bincode = { version = "2.0.1", features = ["serde", "alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 rand = "0.9"
 keccak = "0.2"
-pqcrypto-mlkem = "0.1"
-pqcrypto-mldsa = "0.1"
-pqcrypto-traits = "0.3"
+ml-kem = { version = "0.3", features = ["getrandom"] }
+ml-dsa = "0.1"
 
 [[bench]]
 name = "rom"

--- a/hekate/examples/keccak.rs
+++ b/hekate/examples/keccak.rs
@@ -161,8 +161,8 @@ fn generate_cpu_trace(calls: &[([Block64; 25], [Block64; 25])], num_rows: usize)
 
         // Input row:
         // write pre-permutation state
-        for i in 0..25 {
-            tb.set_b64(i, row, input[i]).unwrap();
+        for (i, &val) in input.iter().enumerate() {
+            tb.set_b64(i, row, val).unwrap();
         }
 
         tb.set_bit(CpuKeccakColumns::SELECTOR, row, Bit::ONE)
@@ -173,8 +173,8 @@ fn generate_cpu_trace(calls: &[([Block64; 25], [Block64; 25])], num_rows: usize)
 
         // Output row:
         // write post-permutation state
-        for i in 0..25 {
-            tb.set_b64(i, row, output[i]).unwrap();
+        for (i, &val) in output.iter().enumerate() {
+            tb.set_b64(i, row, val).unwrap();
         }
 
         tb.set_bit(CpuKeccakColumns::SELECTOR, row, Bit::ONE)

--- a/hekate/examples/keccak_inline.rs
+++ b/hekate/examples/keccak_inline.rs
@@ -234,8 +234,8 @@ fn generate_combined_trace(
         assert!(row + 25 <= num_rows, "CPU trace overflow");
 
         // Input row
-        for i in 0..25 {
-            tb.set_b64(i, row, input[i])?;
+        for (i, &val) in input.iter().enumerate() {
+            tb.set_b64(i, row, val)?;
         }
 
         tb.set_bit(CpuKeccakColumns::SELECTOR, row, Bit::ONE)?;
@@ -243,8 +243,8 @@ fn generate_combined_trace(
         row += 24;
 
         // Output row
-        for i in 0..25 {
-            tb.set_b64(i, row, output[i])?;
+        for (i, &val) in output.iter().enumerate() {
+            tb.set_b64(i, row, val)?;
         }
 
         tb.set_bit(CpuKeccakColumns::SELECTOR, row, Bit::ONE)?;

--- a/hekate/examples/mldsa.rs
+++ b/hekate/examples/mldsa.rs
@@ -48,8 +48,8 @@ use hekate_program::permutation::PermutationCheckSpec;
 use hekate_program::{Air, Program, ProgramInstance, ProgramWitness};
 use hekate_prover_sys::prove;
 use hekate_verifier::HekateVerifier;
-use pqcrypto_mldsa::{mldsa44, mldsa65, mldsa87};
-use pqcrypto_traits::sign::{DetachedSignature, PublicKey};
+use ml_dsa::signature::{Keypair, Signer};
+use ml_dsa::{B32, MlDsa44, MlDsa65, MlDsa87, SigningKey};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 
@@ -249,43 +249,52 @@ fn run_mldsa(label: &str, level: MlDsaLevel, pk_bytes: &[u8], sig_bytes: &[u8], 
 
 fn main() {
     let level_arg = std::env::args().nth(1).unwrap_or_else(|| "65".to_string());
+
+    let mut seed = [0u8; 32];
+    OsRng.try_fill_bytes(&mut seed).unwrap();
+
+    let xi = B32::from(seed);
+
     match level_arg.as_str() {
         "44" => {
-            let (pk, sk) = mldsa44::keypair();
+            let key = SigningKey::<MlDsa44>::from_seed(&xi);
             let msg = b"Hekate ML-DSA-44 verification example";
-            let sig = mldsa44::detached_sign(msg, &sk);
+            let pk = key.verifying_key().encode();
+            let sig = key.sign(msg).encode();
 
             run_mldsa(
                 "ML-DSA-44 Signature Verification",
                 MlDsaLevel::MLDSA_44,
-                pk.as_bytes(),
-                sig.as_bytes(),
+                &pk,
+                &sig,
                 msg,
             );
         }
         "65" => {
-            let (pk, sk) = mldsa65::keypair();
+            let key = SigningKey::<MlDsa65>::from_seed(&xi);
             let msg = b"Hekate ML-DSA-65 verification example";
-            let sig = mldsa65::detached_sign(msg, &sk);
+            let pk = key.verifying_key().encode();
+            let sig = key.sign(msg).encode();
 
             run_mldsa(
                 "ML-DSA-65 Signature Verification",
                 MlDsaLevel::MLDSA_65,
-                pk.as_bytes(),
-                sig.as_bytes(),
+                &pk,
+                &sig,
                 msg,
             );
         }
         "87" => {
-            let (pk, sk) = mldsa87::keypair();
+            let key = SigningKey::<MlDsa87>::from_seed(&xi);
             let msg = b"Hekate ML-DSA-87 verification example";
-            let sig = mldsa87::detached_sign(msg, &sk);
+            let pk = key.verifying_key().encode();
+            let sig = key.sign(msg).encode();
 
             run_mldsa(
                 "ML-DSA-87 Signature Verification",
                 MlDsaLevel::MLDSA_87,
-                pk.as_bytes(),
-                sig.as_bytes(),
+                &pk,
+                &sig,
                 msg,
             );
         }

--- a/hekate/examples/mlkem.rs
+++ b/hekate/examples/mlkem.rs
@@ -46,8 +46,10 @@ use hekate_program::permutation::PermutationCheckSpec;
 use hekate_program::{Air, Program, ProgramInstance, ProgramWitness};
 use hekate_prover_sys::prove;
 use hekate_verifier::HekateVerifier;
-use pqcrypto_mlkem::mlkem768;
-use pqcrypto_traits::kem::{Ciphertext as _, SecretKey as _, SharedSecret as _};
+#[allow(deprecated)]
+use ml_kem::ExpandedKeyEncoding;
+use ml_kem::kem::Encapsulate;
+use ml_kem::{DecapsulationKey, MlKem768};
 use rand::TryRngCore;
 use rand::rngs::OsRng;
 
@@ -122,34 +124,6 @@ impl Program<F> for MlKemDecapsProgram {
 fn main() {
     common::init("ML-KEM-768 Decapsulation");
 
-    // Trace sizes for ML-KEM-768 decapsulation:
-    //
-    // Forward NTTs:
-    // 6 × 1024 = 6144 butterfly ops
-    //
-    // INTT (GS→CT decomp):
-    // 5 × (2048+256) = 11520 ops
-    //
-    // Basemul:
-    // 15 × 256 = 3840 mul-only ops
-    //
-    // Total NTT ops:
-    // ~21504 → 32768
-    //
-    // Keccak:
-    // ~63 perms × 25 rows = 1575 → 2048
-    //
-    // Ctrl:
-    // NTT + Keccak dispatches → 32768
-    //
-    // Twiddle:
-    // 1 entry per NTT op → 32768
-    //
-    // Basemul:
-    // 15 poly muls × 256 ops = 3840 → 4096
-    //
-    // RAM:
-    // ~10 polys × 256 × 2 (write+read) = ~5120 → 8192
     let params = MlKemParams {
         ctrl_rows: 1 << 16,    // 65536 (NTT + Keccak + basemul + RAM dispatch)
         keccak_rows: 1 << 11,  // 2048
@@ -162,18 +136,29 @@ fn main() {
     let cpu_num_rows: usize = 1 << 10; // 1024
 
     // Phase 1:
-    // NIST reference keygen
-    let (nist_pk, nist_sk) = common::phase("Key Generation (NIST)", mlkem768::keypair);
+    // NIST reference keygen (RustCrypto ml-kem)
+    let dk = common::phase("Key Generation (NIST)", || {
+        let mut seed = [0u8; 64];
+        OsRng.try_fill_bytes(&mut seed).unwrap();
+
+        DecapsulationKey::<MlKem768>::from_seed(seed.into())
+    });
 
     // Phase 2:
     // NIST reference encapsulation
-    let (nist_ss, nist_ct) =
-        common::phase("Encapsulation (NIST)", || mlkem768::encapsulate(&nist_pk));
+    let (ct_enc, ss_enc) = common::phase("Encapsulation (NIST)", || {
+        dk.encapsulation_key().encapsulate()
+    });
 
-    let ct = nist_ct.as_bytes();
-    let sk = nist_sk.as_bytes();
+    // The chiplet consumes the expanded FIPS 203
+    // decapsulation key, not the 64-byte seed.
+    #[allow(deprecated)]
+    let dk_expanded = dk.to_expanded_bytes();
 
-    let expected_ss = nist_ss.as_bytes();
+    let ct = ct_enc.as_slice();
+    let sk = dk_expanded.as_slice();
+
+    let expected_ss = ss_enc.as_slice();
 
     println!("  Ciphertext:     {} bytes", ct.len());
 


### PR DESCRIPTION
Replace the unmaintained `pqcrypto-*` PQClean C bindings (RUSTSEC-2026-0161/0162/0163/0166) with pure-Rust RustCrypto `ml-kem` 0.3 / `ml-dsa` 0.1, and bump yanked `aes` 0.9.0 -> 0.9.1. Dev- and build-dependency only: no library API, wire format, `program_id`, or proof change. `cargo deny check` is clean with no advisory ignores added.

## Changes

### Migrate pqcrypto -> RustCrypto ml-kem/ml-dsa; bump yanked aes

- `hekate-prover-sys` build script verifies the prover cdylib's ML-DSA-65 signature with `ml-dsa` (was `pqcrypto-mldsa`); existing signatures verify unchanged (FIPS 204, empty context).
- `mldsa` / `mlkem` examples produce reference vectors with `ml-dsa` / `ml-kem`. Encapsulation uses the getrandom `encapsulate()`; the chiplet's expanded decapsulation key comes from `to_expanded_bytes` (`#[allow(deprecated)]`, the only ml-kem 0.3 path to that format).
- `aes` 0.9.0 (yanked) -> 0.9.1.
- Drop the now-stale `paste`/pqcrypto advisory ignore from `deny.toml`.

### Fix needless_range_loop in keccak examples

- `keccak` / `keccak_inline`: `for i in 0..25 { … arr[i] }` -> `for (i, &val) in arr.iter().enumerate()`.

## Compatibility

- Dev/build-dependency only, no library API, wire, `program_id`, or proof change; existing proofs and signed cdylibs verify unchanged.
- `cargo deny check`: advisories clean, no ignores added.