### PR TITLE
Derive PQC chiplet trace sizing from the security level

### DIFF
--- a/hekate-pqc/src/mldsa/mod.rs
+++ b/hekate-pqc/src/mldsa/mod.rs
@@ -179,7 +179,7 @@ impl MlDsaLevel {
 
 /// ML-DSA chiplet trace sizing.
 #[derive(Clone, Debug)]
-pub struct MlDsaParams {
+pub(crate) struct MlDsaParams {
     pub ctrl_rows: usize,
     pub keccak_rows: usize,
     pub ntt_rows: usize,
@@ -189,18 +189,28 @@ pub struct MlDsaParams {
     pub ram_rows: usize,
 }
 
-impl Default for MlDsaParams {
-    /// Default sizing for ML-DSA-65
-    /// single verification.
-    fn default() -> Self {
-        Self {
-            ctrl_rows: 1 << 15,     // 32K
-            keccak_rows: 1 << 11,   // 2K
-            ntt_rows: 1 << 16,      // 64K
-            twiddle_rows: 1 << 10,  // 1K
-            norm_rows: 1 << 11,     // 2K
-            highbits_rows: 1 << 11, // 2K
-            ram_rows: 1 << 15,      // 32K
+impl MlDsaParams {
+    /// Sizes validated against the FIPS 204 KAT vectors.
+    pub(crate) fn for_level(level: MlDsaLevel) -> Self {
+        match level.k() {
+            8 => Self {
+                ctrl_rows: 1 << 17,
+                keccak_rows: 1 << 14,
+                ntt_rows: 1 << 17,
+                twiddle_rows: 1 << 17,
+                norm_rows: 1 << 12,
+                highbits_rows: 1 << 12,
+                ram_rows: 1 << 17,
+            },
+            _ => Self {
+                ctrl_rows: 1 << 16,
+                keccak_rows: 1 << 13,
+                ntt_rows: 1 << 16,
+                twiddle_rows: 1 << 16,
+                norm_rows: 1 << 11,
+                highbits_rows: 1 << 11,
+                ram_rows: 1 << 16,
+            },
         }
     }
 }
@@ -222,7 +232,9 @@ where
     <F as PackableField>::Packed: Copy + Send + Sync,
     Flat<F>: Send + Sync,
 {
-    pub fn new(level: MlDsaLevel, params: MlDsaParams) -> Self {
+    pub fn new(level: MlDsaLevel) -> Self {
+        let params = MlDsaParams::for_level(level);
+
         let ctrl = MlDsaCtrlChiplet::new(params.ctrl_rows);
         let keccak = KeccakChiplet::new(params.keccak_rows);
         let ntt = NttChiplet::new(MLDSA_Q, params.ntt_rows);
@@ -257,10 +269,6 @@ where
 
     pub fn level(&self) -> MlDsaLevel {
         self.level
-    }
-
-    pub fn params(&self) -> &MlDsaParams {
-        &self.params
     }
 }
 

--- a/hekate-pqc/src/mlkem/ctrl.rs
+++ b/hekate-pqc/src/mlkem/ctrl.rs
@@ -1449,7 +1449,7 @@ impl<F: TowerField> Air<F> for MlKemCtrlChiplet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mlkem::{MLKEM_Q, MlKemChiplet, MlKemLevel, MlKemParams};
+    use crate::mlkem::{MLKEM_Q, MlKemChiplet, MlKemLevel};
     use hekate_core::trace::TraceColumn;
     use hekate_math::{Bit, Block128};
     #[allow(deprecated)]
@@ -1578,15 +1578,7 @@ mod tests {
         let nist_ct = nist_ct.as_slice().to_vec();
         let nist_sk = dk.to_expanded_bytes().as_slice().to_vec();
 
-        let params = MlKemParams {
-            ctrl_rows: 1 << 16,
-            keccak_rows: 1 << 11,
-            ntt_rows: 1 << 15,
-            twiddle_rows: 1 << 15,
-            basemul_rows: 1 << 12,
-            ram_rows: 1 << 16,
-        };
-        let chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params);
+        let chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
         let (traces, _) = chiplet.generate_traces(&nist_ct, &nist_sk).unwrap();
 
         let ctrl = &traces[0];

--- a/hekate-pqc/src/mlkem/mod.rs
+++ b/hekate-pqc/src/mlkem/mod.rs
@@ -126,7 +126,7 @@ impl MlKemLevel {
 /// ML-KEM chiplet trace sizing.
 /// Internal sub-chiplet row counts.
 #[derive(Clone, Debug)]
-pub struct MlKemParams {
+pub(crate) struct MlKemParams {
     pub ctrl_rows: usize,
     pub keccak_rows: usize,
     pub ntt_rows: usize,
@@ -135,17 +135,20 @@ pub struct MlKemParams {
     pub ram_rows: usize,
 }
 
-impl Default for MlKemParams {
-    /// Use `Default` for ML-KEM-768 single-decaps.
-    /// Override for batched proofs or custom sizing.
-    fn default() -> Self {
+impl MlKemParams {
+    /// Sizes validated against the FIPS 203 KAT vectors.
+    pub(crate) fn for_level(level: MlKemLevel) -> Self {
+        let k = level.k;
+        let keccak_shift = if k >= 4 { 12 } else { 11 };
+        let ctrl_shift = if k >= 4 { 17 } else { 16 };
+
         Self {
-            ctrl_rows: 1 << 14,    // 16K
-            keccak_rows: 1 << 9,   // 512
-            ntt_rows: 1 << 15,     // 32K
-            twiddle_rows: 1 << 10, // 1K
-            basemul_rows: 1 << 12, // 4K
-            ram_rows: 1 << 15,     // 32K
+            ctrl_rows: 1 << ctrl_shift,
+            keccak_rows: 1 << keccak_shift,
+            ntt_rows: 1 << (14 + k.div_ceil(3)),
+            twiddle_rows: 1 << (14 + k.div_ceil(3)),
+            basemul_rows: 1 << (11 + k.div_ceil(2)),
+            ram_rows: 1 << (14 + k.div_ceil(2)),
         }
     }
 }
@@ -158,10 +161,7 @@ impl Default for MlKemParams {
 /// # Usage
 ///
 /// ```ignore
-/// let mlkem = MlKemChiplet::new(
-///     MlKemLevel::MLKEM_768,
-///     MlKemParams::default(),
-/// );
+/// let mlkem = MlKemChiplet::new(MlKemLevel::MLKEM_768);
 ///
 /// // In Program impl:
 /// fn chiplet_defs(&self) -> Vec<ChipletDef<F>> {
@@ -185,7 +185,9 @@ where
     <F as PackableField>::Packed: Copy + Send + Sync,
     Flat<F>: Send + Sync,
 {
-    pub fn new(level: MlKemLevel, params: MlKemParams) -> Self {
+    pub fn new(level: MlKemLevel) -> Self {
+        let params = MlKemParams::for_level(level);
+
         let ctrl = MlKemCtrlChiplet::new(params.ctrl_rows);
         let keccak = KeccakChiplet::new(params.keccak_rows);
         let ntt = NttChiplet::new(MLKEM_Q, params.ntt_rows);
@@ -218,10 +220,6 @@ where
 
     pub fn level(&self) -> MlKemLevel {
         self.level
-    }
-
-    pub fn params(&self) -> &MlKemParams {
-        &self.params
     }
 }
 
@@ -344,17 +342,7 @@ mod tests {
 
     #[test]
     fn composite_builds_six_chiplets() {
-        let mlkem = MlKemChiplet::<F>::new(
-            MlKemLevel::MLKEM_768,
-            MlKemParams {
-                ctrl_rows: 16,
-                keccak_rows: 32,
-                ntt_rows: 16,
-                twiddle_rows: 16,
-                basemul_rows: 16,
-                ram_rows: 16,
-            },
-        );
+        let mlkem = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
         assert_eq!(mlkem.composite().len(), 6);
         assert_eq!(mlkem.composite().name(), "mlkem");
@@ -362,17 +350,7 @@ mod tests {
 
     #[test]
     fn flatten_defs_produces_six_defs() {
-        let mlkem = MlKemChiplet::<F>::new(
-            MlKemLevel::MLKEM_768,
-            MlKemParams {
-                ctrl_rows: 16,
-                keccak_rows: 32,
-                ntt_rows: 16,
-                twiddle_rows: 16,
-                basemul_rows: 16,
-                ram_rows: 16,
-            },
-        );
+        let mlkem = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
         let defs: Vec<ChipletDef<F>> = mlkem.composite().flatten_defs().unwrap();
         assert_eq!(defs.len(), 6);
@@ -380,17 +358,7 @@ mod tests {
 
     #[test]
     fn internal_buses_namespaced() {
-        let mlkem = MlKemChiplet::<F>::new(
-            MlKemLevel::MLKEM_768,
-            MlKemParams {
-                ctrl_rows: 16,
-                keccak_rows: 32,
-                ntt_rows: 16,
-                twiddle_rows: 16,
-                basemul_rows: 16,
-                ram_rows: 16,
-            },
-        );
+        let mlkem = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
         let defs: Vec<ChipletDef<F>> = mlkem.composite().flatten_defs().unwrap();
 
@@ -441,17 +409,7 @@ mod tests {
 
     #[test]
     fn external_bus_spec_returned() {
-        let mlkem = MlKemChiplet::<F>::new(
-            MlKemLevel::MLKEM_768,
-            MlKemParams {
-                ctrl_rows: 16,
-                keccak_rows: 32,
-                ntt_rows: 16,
-                twiddle_rows: 16,
-                basemul_rows: 16,
-                ram_rows: 16,
-            },
-        );
+        let mlkem = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
         let ext = mlkem.composite().external_buses();
         assert_eq!(ext.len(), 2);

--- a/hekate-pqc/tests/mldsa_chiplet.rs
+++ b/hekate-pqc/tests/mldsa_chiplet.rs
@@ -24,7 +24,7 @@ use hekate_keccak::{KeccakChiplet, KeccakWitness};
 use hekate_math::{Bit, Block32, Block64, Block128, Flat, HardwareField, TowerField};
 use hekate_pqc::high_bits::HighBitsLayout;
 use hekate_pqc::mldsa::{
-    self, CpuMlDsaColumns, CpuMlDsaUnit, MlDsaChiplet, MlDsaCtrlColumns, MlDsaLevel, MlDsaParams,
+    self, CpuMlDsaColumns, CpuMlDsaUnit, MlDsaChiplet, MlDsaCtrlColumns, MlDsaLevel,
     MlDsaPublicKey, MlDsaSignature,
 };
 use hekate_program::chiplet::ChipletDef;
@@ -107,37 +107,13 @@ impl Program<F> for MlDsaTestProgram {
     }
 }
 
-fn test_params(level: &MlDsaLevel) -> MlDsaParams {
-    match level.k() {
-        8 => MlDsaParams {
-            ctrl_rows: 1 << 17,
-            keccak_rows: 1 << 14,
-            ntt_rows: 1 << 17,
-            twiddle_rows: 1 << 17,
-            norm_rows: 1 << 12,
-            highbits_rows: 1 << 12,
-            ram_rows: 1 << 17,
-        },
-        _ => MlDsaParams {
-            ctrl_rows: 1 << 16,
-            keccak_rows: 1 << 13,
-            ntt_rows: 1 << 16,
-            twiddle_rows: 1 << 16,
-            norm_rows: 1 << 11,
-            highbits_rows: 1 << 11,
-            ram_rows: 1 << 16,
-        },
-    }
-}
-
 fn prove_and_verify_mldsa(
     level: MlDsaLevel,
     pk_bytes: &[u8],
     sig_bytes: &[u8],
     msg: &[u8],
 ) -> Result<bool, String> {
-    let params = test_params(&level);
-    let mldsa_chiplet = MlDsaChiplet::<F>::new(level, params);
+    let mldsa_chiplet = MlDsaChiplet::<F>::new(level);
 
     let pk = MlDsaPublicKey::from_bytes(level, pk_bytes);
     let sig = MlDsaSignature::from_bytes(level, sig_bytes).expect("NIST signature should parse");
@@ -321,8 +297,7 @@ where
     let (nist_pk, nist_sig) = nist_mldsa_65(msg);
 
     let level = MlDsaLevel::MLDSA_65;
-    let params = test_params(&level);
-    let mldsa_chiplet = MlDsaChiplet::<F>::new(level, params);
+    let mldsa_chiplet = MlDsaChiplet::<F>::new(level);
 
     let pk = MlDsaPublicKey::from_bytes(level, &nist_pk);
     let sig = MlDsaSignature::from_bytes(level, &nist_sig).expect("NIST signature must parse");

--- a/hekate-pqc/tests/mlkem_chiplet.rs
+++ b/hekate-pqc/tests/mlkem_chiplet.rs
@@ -28,7 +28,7 @@ use hekate_crypto::transcript::Transcript;
 use hekate_keccak::{KeccakChiplet, KeccakWitness};
 use hekate_math::{Bit, Block32, Block64, Block128, Flat, HardwareField, TowerField};
 use hekate_pqc::mlkem::{
-    self, CpuMlKemColumns, CpuMlKemUnit, MlKemChiplet, MlKemCtrlColumns, MlKemLevel, MlKemParams,
+    self, CpuMlKemColumns, CpuMlKemUnit, MlKemChiplet, MlKemCtrlColumns, MlKemLevel,
 };
 use hekate_program::chiplet::ChipletDef;
 use hekate_program::constraint::builder::ConstraintSystem;
@@ -126,42 +126,12 @@ impl Program<F> for MlKemTestProgram {
     }
 }
 
-fn params_for_level(level: MlKemLevel) -> MlKemParams {
-    // Scale trace sizes with k.
-    // Keccak:
-    // k^2 sample_ntt calls (each ~3 absorbs)
-    // plus CBD, G, H, J hashes.
-    //
-    // NTT:
-    // scales linearly with k.
-    //
-    // RAM:
-    // scales with k^2 (matrix-vector product).
-    let k = level.k;
-    let keccak_shift = if k >= 4 { 12 } else { 11 };
-    let ctrl_shift = if k >= 4 { 17 } else { 16 };
-
-    MlKemParams {
-        ctrl_rows: 1 << ctrl_shift,
-        keccak_rows: 1 << keccak_shift,
-        ntt_rows: 1 << (14 + k.div_ceil(3)),
-        twiddle_rows: 1 << (14 + k.div_ceil(3)),
-        basemul_rows: 1 << (11 + k.div_ceil(2)),
-        ram_rows: 1 << (14 + k.div_ceil(2)),
-    }
+fn prove_and_verify_mlkem(ct: &[u8], sk: &[u8]) -> Result<bool, String> {
+    prove_and_verify_mlkem_level(MlKemLevel::MLKEM_768, ct, sk)
 }
 
-fn prove_and_verify_mlkem(ct: &[u8], sk: &[u8], params: &MlKemParams) -> Result<bool, String> {
-    prove_and_verify_mlkem_level(MlKemLevel::MLKEM_768, ct, sk, params)
-}
-
-fn prove_and_verify_mlkem_level(
-    level: MlKemLevel,
-    ct: &[u8],
-    sk: &[u8],
-    params: &MlKemParams,
-) -> Result<bool, String> {
-    let mlkem_chiplet = MlKemChiplet::<F>::new(level, params.clone());
+fn prove_and_verify_mlkem_level(level: MlKemLevel, ct: &[u8], sk: &[u8]) -> Result<bool, String> {
+    let mlkem_chiplet = MlKemChiplet::<F>::new(level);
 
     let (chiplet_traces, shared_secret) = mlkem_chiplet
         .generate_traces(ct, sk)
@@ -251,17 +221,6 @@ fn prove_and_verify_mlkem_level(
         .map_err(|e| format!("verifier: {e:?}"))
 }
 
-fn test_params() -> MlKemParams {
-    MlKemParams {
-        ctrl_rows: 1 << 16,
-        keccak_rows: 1 << 11,
-        ntt_rows: 1 << 15,
-        twiddle_rows: 1 << 15,
-        basemul_rows: 1 << 12,
-        ram_rows: 1 << 16,
-    }
-}
-
 /// Builds an honest ML-KEM-768 trace,
 /// applies a tamper closure to the chiplet
 /// traces, runs the prover/verifier, and
@@ -273,8 +232,7 @@ where
 {
     let (ct_bytes, sk_bytes) = nist_mlkem_768();
 
-    let params = test_params();
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params);
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (mut chiplet_traces, shared_secret) = mlkem_chiplet
         .generate_traces(&ct_bytes, &sk_bytes)
@@ -377,8 +335,7 @@ where
 {
     let (ct_bytes, sk_bytes) = nist_mlkem_768();
 
-    let params = test_params();
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params);
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (mut chiplet_traces, shared_secret) = mlkem_chiplet
         .generate_traces(&ct_bytes, &sk_bytes)
@@ -526,7 +483,7 @@ fn mlkem_512_e2e() {
     let level = MlKemLevel::MLKEM_512;
     let (ct, sk) = nist_mlkem_512();
 
-    let result = prove_and_verify_mlkem_level(level, &ct, &sk, &params_for_level(level));
+    let result = prove_and_verify_mlkem_level(level, &ct, &sk);
 
     assert_eq!(result, Ok(true), "ML-KEM-512 E2E: {result:?}");
 }
@@ -537,7 +494,7 @@ fn mlkem_768_e2e() {
     let level = MlKemLevel::MLKEM_768;
     let (ct, sk) = nist_mlkem_768();
 
-    let result = prove_and_verify_mlkem_level(level, &ct, &sk, &params_for_level(level));
+    let result = prove_and_verify_mlkem_level(level, &ct, &sk);
 
     assert_eq!(result, Ok(true), "ML-KEM-768 E2E: {result:?}");
 }
@@ -548,7 +505,7 @@ fn mlkem_1024_e2e() {
     let level = MlKemLevel::MLKEM_1024;
     let (ct, sk) = nist_mlkem_1024();
 
-    let result = prove_and_verify_mlkem_level(level, &ct, &sk, &params_for_level(level));
+    let result = prove_and_verify_mlkem_level(level, &ct, &sk);
 
     assert_eq!(result, Ok(true), "ML-KEM-1024 E2E: {result:?}");
 }
@@ -563,7 +520,7 @@ fn mlkem_1024_e2e() {
 fn honest_prover_succeeds() {
     let (ct, sk) = nist_mlkem_768();
 
-    let result = prove_and_verify_mlkem(&ct, &sk, &test_params());
+    let result = prove_and_verify_mlkem(&ct, &sk);
     assert_eq!(result, Ok(true), "Honest prover must succeed: {result:?}",);
 }
 
@@ -585,7 +542,7 @@ fn wrong_secret_key_rejected() {
     // with wrong key differs). This should still
     // produce a VALID proof, implicit rejection
     // is a valid execution path.
-    let result = prove_and_verify_mlkem(&ct1, &sk2, &test_params());
+    let result = prove_and_verify_mlkem(&ct1, &sk2);
 
     // This SHOULD succeed, implicit rejection
     // is valid behavior. The proof proves that
@@ -614,7 +571,7 @@ fn tampered_ciphertext_valid_rejection() {
 
     // Decaps with tampered ct takes rejection path.
     // This is a VALID execution, proof should pass.
-    let result = prove_and_verify_mlkem(&ct_bad, &sk, &test_params());
+    let result = prove_and_verify_mlkem(&ct_bad, &sk);
     assert_eq!(
         result,
         Ok(true),
@@ -641,7 +598,7 @@ fn ram_enforces_ct_comparison() {
     let (ct, sk) = nist_mlkem_768();
 
     // Full prove/verify
-    let result = prove_and_verify_mlkem(&ct, &sk, &test_params());
+    let result = prove_and_verify_mlkem(&ct, &sk);
     assert_eq!(
         result,
         Ok(true),
@@ -666,8 +623,7 @@ fn ram_enforces_ct_comparison() {
 fn exploit_ntt_ram_binding_mismatch() {
     let (ct, sk) = nist_mlkem_768();
 
-    let params = test_params();
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params.clone());
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (mut chiplet_traces, _) = mlkem_chiplet
         .generate_traces(&ct, &sk)
@@ -772,8 +728,7 @@ fn exploit_ntt_ram_binding_mismatch() {
 fn exploit_ntt_flow_connectivity_scramble() {
     let (ct, sk) = nist_mlkem_768();
 
-    let params = test_params();
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params.clone());
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (mut chiplet_traces, _) = mlkem_chiplet
         .generate_traces(&ct, &sk)
@@ -881,8 +836,7 @@ fn exploit_ntt_flow_connectivity_scramble() {
 fn exploit_keccak_input_unbound() {
     let (ct, sk) = nist_mlkem_768();
 
-    let params = test_params();
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params.clone());
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (mut chiplet_traces, _) = mlkem_chiplet
         .generate_traces(&ct, &sk)

--- a/hekate/examples/mldsa.rs
+++ b/hekate/examples/mldsa.rs
@@ -38,8 +38,7 @@ use hekate::math::{Bit, Block32, Block128};
 use hekate_core::config::Config;
 use hekate_math::TowerField;
 use hekate_pqc::mldsa::{
-    self, CpuMlDsaColumns, CpuMlDsaUnit, MlDsaChiplet, MlDsaLevel, MlDsaParams, MlDsaPublicKey,
-    MlDsaSignature,
+    self, CpuMlDsaColumns, CpuMlDsaUnit, MlDsaChiplet, MlDsaLevel, MlDsaPublicKey, MlDsaSignature,
 };
 use hekate_program::chiplet::ChipletDef;
 use hekate_program::constraint::builder::ConstraintSystem;
@@ -114,33 +113,9 @@ impl Program<F> for MlDsaVerifyProgram {
 // Main
 // =================================================================
 
-fn params_for_level(level: &MlDsaLevel) -> MlDsaParams {
-    match level.k() {
-        8 => MlDsaParams {
-            ctrl_rows: 1 << 17,
-            keccak_rows: 1 << 14,
-            ntt_rows: 1 << 17,
-            twiddle_rows: 1 << 17,
-            norm_rows: 1 << 12,
-            highbits_rows: 1 << 12,
-            ram_rows: 1 << 17,
-        },
-        _ => MlDsaParams {
-            ctrl_rows: 1 << 16,
-            keccak_rows: 1 << 13,
-            ntt_rows: 1 << 16,
-            twiddle_rows: 1 << 16,
-            norm_rows: 1 << 11,
-            highbits_rows: 1 << 11,
-            ram_rows: 1 << 16,
-        },
-    }
-}
-
 fn run_mldsa(label: &str, level: MlDsaLevel, pk_bytes: &[u8], sig_bytes: &[u8], msg: &[u8]) {
     common::init(label);
 
-    let params = params_for_level(&level);
     let cpu_num_rows: usize = 1 << 10;
     let domain = b"ML-DSA_Verify";
 
@@ -153,7 +128,7 @@ fn run_mldsa(label: &str, level: MlDsaLevel, pk_bytes: &[u8], sig_bytes: &[u8], 
 
     // Phase 1:
     // Generate traces.
-    let mldsa_chiplet = MlDsaChiplet::<F>::new(level, params);
+    let mldsa_chiplet = MlDsaChiplet::<F>::new(level);
 
     let (cpu_trace, chiplet_traces, io_public) = common::phase("Trace Generation", || {
         let chiplet_traces = mldsa_chiplet

--- a/hekate/examples/mlkem.rs
+++ b/hekate/examples/mlkem.rs
@@ -36,9 +36,7 @@ use hekate::crypto::transcript::Transcript;
 use hekate::math::{Bit, Block32, Block128};
 use hekate_core::config::Config;
 use hekate_math::TowerField;
-use hekate_pqc::mlkem::{
-    self, CpuMlKemColumns, CpuMlKemUnit, MlKemChiplet, MlKemLevel, MlKemParams,
-};
+use hekate_pqc::mlkem::{self, CpuMlKemColumns, CpuMlKemUnit, MlKemChiplet, MlKemLevel};
 use hekate_program::chiplet::ChipletDef;
 use hekate_program::constraint::builder::ConstraintSystem;
 use hekate_program::constraint::{BoundaryConstraint, ConstraintAst};
@@ -124,15 +122,6 @@ impl Program<F> for MlKemDecapsProgram {
 fn main() {
     common::init("ML-KEM-768 Decapsulation");
 
-    let params = MlKemParams {
-        ctrl_rows: 1 << 16,    // 65536 (NTT + Keccak + basemul + RAM dispatch)
-        keccak_rows: 1 << 11,  // 2048
-        ntt_rows: 1 << 15,     // 32768
-        twiddle_rows: 1 << 15, // 32768
-        basemul_rows: 1 << 12, // 4096
-        ram_rows: 1 << 16,     // 65536 (decrypt + encrypt + ct comparison)
-    };
-
     let cpu_num_rows: usize = 1 << 10; // 1024
 
     // Phase 1:
@@ -164,7 +153,7 @@ fn main() {
 
     // Phase 3:
     // Generate traces.
-    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768, params);
+    let mlkem_chiplet = MlKemChiplet::<F>::new(MlKemLevel::MLKEM_768);
 
     let (cpu_trace, chiplet_traces, shared_secret) = common::phase("Trace Generation", || {
         let (chiplet_traces, shared_secret) = mlkem_chiplet


### PR DESCRIPTION
Closed #12

`MlKemChiplet::new` / `MlDsaChiplet::new` drop the `params` argument and derive trace sizing from the level via `{MlKem,MlDsa}Params::for_level`. The per-level sizing tables that lived in test/example helpers (`test_params`, `params_for_level`) collapse into that one production source; the never-validated `Default` impls and the unused `params()` getter are removed, and both `*Params` structs become `pub(crate)`. Sizing is public and traces only gain padding, **no proof, wire, or `program_id` change**.

## Changes

### Derive chiplet sizing from level, drop params argument

- `MlKemParams::for_level(level)` replaces `Default`; body is verbatim the deleted `params_for_level` (`keccak`/`ctrl` shift on `k >= 4`, `ntt`/`twiddle = 1 << (14 + k.div_ceil(3))`, `basemul = 1 << (11 + k.div_ceil(2))`, `ram = 1 << (14 + k.div_ceil(2))`).
- `MlKemChiplet::new(level)` derives params internally; `MlKemParams` becomes `pub(crate)`; `params()` getter deleted.
- e2e paths (`mlkem_512/768/1024_e2e`) byte-identical: `for_level == params_for_level`.
- Paths that used the fixed `test_params()`/inline sizing (ctrl `decaps` unit test, tamper + scribble + `exploit_*` helpers, decaps example) move `basemul_rows 1 << 12 -> 1 << 13`; all other dims identical. Enlargement only, and `mlkem_768_e2e` already proves at `basemul = 8192`.

### Derive chiplet sizing from level, drop params argument

- `MlDsaParams::for_level(level)` replaces `Default`; body is verbatim the deleted `test_params` / `params_for_level` (`level.k() == 8` branch vs default).
- `MlDsaChiplet::new(level)` derives params internally; `MlDsaParams` becomes `pub(crate)`; `params()` getter deleted.
- Behaviorally a no-op: every call site already passed exactly `for_level`'s values.

## Compatibility

- **Public-API break** in `hekate-pqc`: `new` loses its `params` arg, `{MlKem,MlDsa}Params` go
  `pub(crate)`, `params()` removed. 
- **Non-breaking for proofs.** Sizing is public (absorbed as `num_rows`), the honest witness occupies the same real rows, only padding grows; existing proofs verify unchanged.
- Removes the smaller, never-tested `Default` sizing, so no path can select an under-sized trace.