### PR TITLE
Bind LogUp claimed_sums on tables that declare no permutation bus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
             sdk:
               - 'hekate-sdk/**'
               - 'hekate-verifier/**'
+              - 'hekate-gadgets/**'
               - 'hekate-program/**'
               - 'hekate-core/**'
               - 'hekate-crypto/**'
@@ -86,6 +87,10 @@ jobs:
               - 'Cargo.lock'
             keccak:
               - 'hekate-keccak/**'
+              - 'hekate-verifier/**'
+              - 'hekate-sdk/**'
+              - 'hekate-prover-sys/**'
+              - 'hekate-scribble/**'
               - 'hekate-program/**'
               - 'hekate-core/**'
               - 'hekate-crypto/**'
@@ -93,6 +98,10 @@ jobs:
               - 'Cargo.lock'
             aes:
               - 'hekate-aes/**'
+              - 'hekate-verifier/**'
+              - 'hekate-sdk/**'
+              - 'hekate-prover-sys/**'
+              - 'hekate-scribble/**'
               - 'hekate-program/**'
               - 'hekate-core/**'
               - 'hekate-crypto/**'
@@ -100,6 +109,10 @@ jobs:
               - 'Cargo.lock'
             pqc:
               - 'hekate-pqc/**'
+              - 'hekate-verifier/**'
+              - 'hekate-sdk/**'
+              - 'hekate-prover-sys/**'
+              - 'hekate-scribble/**'
               - 'hekate-keccak/**'
               - 'hekate-gadgets/**'
               - 'hekate-program/**'

--- a/hekate-verifier/src/lib.rs
+++ b/hekate-verifier/src/lib.rs
@@ -645,45 +645,41 @@ where
         // Constraint System Setup
         // =========================================================
 
-        // Validate LogUp aux structure and bind
-        // claimed_sums into the transcript before
-        // drawing alpha / r_zerocheck so the
-        // ZeroCheck challenges depend on the
-        // bus-sum target.
-        if !bus_specs.is_empty() {
-            if logup_aux.claimed_sums.len() != bus_specs.len() {
+        // Validate LogUp aux structure and bind claimed_sums
+        // into the transcript before drawing alpha / r_zerocheck,
+        // the ZeroCheck challenges depend on the bus-sum target.
+        if logup_aux.claimed_sums.len() != bus_specs.len() {
+            return Err(errors::Error::Protocol {
+                protocol: "verifier",
+                message: "logup_aux claimed_sums length mismatch with bus_specs",
+            });
+        }
+
+        if logup_aux.h_evals.len() != bus_specs.len() {
+            return Err(errors::Error::Protocol {
+                protocol: "verifier",
+                message: "logup_aux h_evals length mismatch with bus_specs",
+            });
+        }
+
+        for (i, ((h_bus, _), (claim_bus, _))) in logup_aux
+            .h_evals
+            .iter()
+            .zip(logup_aux.claimed_sums.iter())
+            .enumerate()
+        {
+            if h_bus != claim_bus {
                 return Err(errors::Error::Protocol {
                     protocol: "verifier",
-                    message: "logup_aux claimed_sums length mismatch with bus_specs",
+                    message: "logup_aux bus_id order diverges between h_evals and claimed_sums",
                 });
             }
 
-            if logup_aux.h_evals.len() != bus_specs.len() {
+            if h_bus.as_str() != bus_specs[i].0.as_str() {
                 return Err(errors::Error::Protocol {
                     protocol: "verifier",
-                    message: "logup_aux h_evals length mismatch with bus_specs",
+                    message: "logup_aux bus_id does not match bus_specs ordering",
                 });
-            }
-
-            for (i, ((h_bus, _), (claim_bus, _))) in logup_aux
-                .h_evals
-                .iter()
-                .zip(logup_aux.claimed_sums.iter())
-                .enumerate()
-            {
-                if h_bus != claim_bus {
-                    return Err(errors::Error::Protocol {
-                        protocol: "verifier",
-                        message: "logup_aux bus_id order diverges between h_evals and claimed_sums",
-                    });
-                }
-
-                if h_bus.as_str() != bus_specs[i].0.as_str() {
-                    return Err(errors::Error::Protocol {
-                        protocol: "verifier",
-                        message: "logup_aux bus_id does not match bus_specs ordering",
-                    });
-                }
             }
         }
 
@@ -691,6 +687,7 @@ where
 
         let alpha_tower = transcript.challenge_field::<F>(b"alpha")?;
         let alpha = alpha_tower.to_hardware();
+
         let r_zerocheck = (0..num_vars)
             .map(|_| {
                 transcript
@@ -707,14 +704,13 @@ where
             sumcheck_degree = sumcheck_degree.max(2);
         }
 
-        // LogUp consistency `h · key · Eq` is degree 3.
+        // LogUp consistency `h · key · Eq` is degree 3
         if !bus_specs.is_empty() {
             sumcheck_degree = sumcheck_degree.max(3);
         }
 
-        // LogUp α_pow offset must match
-        // the prover's continuation past
-        // AIR + boundary + blinding.
+        // LogUp α_pow offset must match the prover's
+        // continuation past AIR + boundary + blinding.
         let logup_alpha_offset =
             ast.roots.len() + boundary_constraints.len() + config.sumcheck_blinding_factor;
 

--- a/hekate/tests/bus_security.rs
+++ b/hekate/tests/bus_security.rs
@@ -713,3 +713,55 @@ fn logup_bus_id_proof_label_diverged_from_program_specs_rejected() {
         "SECURITY FAILURE: proof bus_id labels diverge from program bus_specs"
     );
 }
+
+// =====================================================
+// Zero-bus table must present empty LogUp aux
+// =====================================================
+
+#[test]
+fn zero_bus_main_emits_empty_logup_aux() {
+    let (_air, _instance, _config, proof) = multibus_proof();
+
+    assert!(
+        proof.main_logup_aux.claimed_sums.is_empty(),
+        "MultiBusProgram main declares no permutation_checks; \
+         the honest prover must emit empty claimed_sums"
+    );
+
+    assert!(
+        proof.main_logup_aux.h_evals.is_empty(),
+        "zero-bus main must emit empty h_evals"
+    );
+}
+
+#[test]
+fn zero_bus_main_injected_claimed_sum_rejected() {
+    let (air, instance, config, mut proof) = multibus_proof();
+
+    assert!(
+        proof.main_logup_aux.claimed_sums.is_empty(),
+        "precondition: MultiBusProgram main is a zero-bus table"
+    );
+
+    proof
+        .main_logup_aux
+        .claimed_sums
+        .push((MULTI_BUS_0.into(), F::ONE));
+
+    let mut vt = Transcript::<H>::new(b"AuditP0");
+
+    match HekateVerifier::<F, H>::verify(&air, &instance, &proof, &mut vt, &config) {
+        Err(e) => {
+            let msg = format!("{e:?}");
+            assert!(
+                msg.contains("claimed_sums length"),
+                "expected the empty-bus_specs claimed_sums length guard, got: {msg}"
+            );
+        }
+        Ok(v) => panic!(
+            "SECURITY FAILURE: a zero-bus table presented a non-empty \
+             claimed_sum and verify returned Ok({v}); an unbound endpoint \
+             would enter cross-bus matching"
+        ),
+    }
+}


### PR DESCRIPTION
Closes #19 

A table with no permutation checks accepted a prover-supplied `claimed_sums` vector that no ZeroCheck bound, and that vector still entered cross-bus matching, a free term for forging bus cancellation. This PR runs the `claimed_sums`/`h_evals` length and `bus_id` checks unconditionally, forcing a zero-bus table to present empty vectors. Verifier-only, proof bytes and transcript unchanged; every 0.31.0 proof verifies without re-proving.

## The gap

`verify_zerocheck` gated its LogUp aux validation behind `if !bus_specs.is_empty()`. A table declaring no bus reached cross-bus matching with an unchecked `claimed_sums`: it never entered the sumcheck initial claim or the `r_final` consistency term (both gated the same way), yet it was absorbed into the transcript and harvested by `check_bus_sum_matching`, which groups endpoints by `bus_id` string without checking membership in the program's declared buses. A prover holding one real bus and one zero-bus table forges an imbalance `δ` on the real bus and injects `(real_bus_id, δ)` through the zero-bus table; in characteristic two the endpoint total cancels and the proof verifies. `Program::permutation_checks` defaults to empty; the class is every AIR that does not override it. The shipped circuits declare a bus on every table and are unaffected. The gap is live for any program that pairs a bus-free table with a real bus.

## Changes

### Unconditional LogUp aux validation (hekate-verifier)

The `claimed_sums.len() == bus_specs.len()` and `h_evals.len() == bus_specs.len()` checks and the per-endpoint `bus_id` ordering check move out of the `if !bus_specs.is_empty()` block. For a table with no declared bus this forces both vectors empty, closing the injection term before cross-bus matching. Every declared bus keeps its existing binding: length, order, and the ZeroCheck consistency identity. The honest prover emits empty aux for a zero-bus table; no proof bytes change and every shipped proof verifies unmodified.

### Regression tests (hekate/tests/bus_security.rs)

`MultiBusProgram`'s main trace declares no bus and its two chiplets share three buses, the exact zero-bus-plus-real-bus shape. `zero_bus_main_emits_empty_logup_aux` pins the honest invariant: the main trace's `claimed_sums` and `h_evals` are empty. `zero_bus_main_injected_claimed_sum_rejected` pushes a phantom `(bus_id, value)` onto the zero-bus main aux and asserts the verifier rejects at the length gate. Reverting the guard fails the injection test.

## Compatibility

- Verifier-only. No wire, transcript, `Config`, or `program_id` change.
- Proof bytes unchanged; every 0.31.0 proof verifies without re-proving.
- No prover, chiplet, or example change.

## Out of scope

- Binding `program_id` at verify time. The verifier evaluates its own program's constraints at `r_final`; the shipped local-program model already enforces the circuit it holds, and absorbing `program_id` adds fail-fast on mismatch, not soundness, at the cost of a breaking transcript change. The reconstruct-from-wire bundle path, which trusts wire config and a hash that omits chiplet `num_columns` and `virtual_column_layout`, needs a trusted `program_id` comparison at the SDK boundary rather than a transcript absorption. Both are separate from this gap, which lives entirely in the verifier's LogUp aux handling.
- Broadening the zk-scribble mutation classes beyond selector flips.